### PR TITLE
RMET-615 SafariViewController Plugin - Include queries section to add chrome tabs support for Android > 11

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,12 +38,23 @@
   </platform>
 
   <platform name="android">
+
     <config-file target="config.xml" parent="/*">
       <feature name="SafariViewController">
         <param name="android-package" value="com.customtabplugin.ChromeCustomTabPlugin"/>
         <param name="onload" value="true" />
       </feature>
     </config-file>
+
+    <config-file target="AndroidManifest.xml" parent="/manifest">
+      <queries>
+        <intent>
+            <action android:name=
+                "android.support.customtabs.action.CustomTabsService" />
+        </intent>
+      </queries>
+    </config-file>
+
     <framework src="build/android/SafariViewController-java18.gradle" custom="true" type="gradleReference" />
     <framework src="androidx.browser:browser:1.3.0" />
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added `queries` section to AndroidManifest.xml so that ChromeTabs is used for Android 11 and above.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
Android 11 has introduced package visibility changes and this queries section is needed to use the ChromeTabs service.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
MABS builds working (7).
Android 11 working now for Google, Facebook and LinkedIn using native implementation of ChromeTabs.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
